### PR TITLE
Refactor/remove handler

### DIFF
--- a/src/main/kotlin/io/mustelidae/riverotter/config/ClientDIConfiguration.kt
+++ b/src/main/kotlin/io/mustelidae/riverotter/config/ClientDIConfiguration.kt
@@ -1,19 +1,20 @@
-package io.mustelidae.riverotter.domain.client
+package io.mustelidae.riverotter.config
 
-import io.mustelidae.riverotter.config.AppEnvironment
 import io.mustelidae.riverotter.domain.client.abstractapi.WorldHolidayClient
 import io.mustelidae.riverotter.domain.client.abstractapi.WorldHolidayDummyClient
 import io.mustelidae.riverotter.domain.client.abstractapi.WorldHolidayStableClient
 import io.mustelidae.riverotter.domain.client.korea.government.GovernmentOpenClient
 import io.mustelidae.riverotter.domain.client.korea.government.GovernmentOpenDummyClient
 import io.mustelidae.riverotter.domain.client.korea.government.GovernmentOpenStableClient
-import org.springframework.stereotype.Component
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 
-@Component
-class ClientHandler(
+@Configuration
+class ClientDIConfiguration(
     val appEnv: AppEnvironment
 ) {
 
+    @Bean
     fun governmentOpenClient(): GovernmentOpenClient {
         return if (appEnv.client.government.useDummy)
             GovernmentOpenDummyClient()
@@ -21,6 +22,7 @@ class ClientHandler(
             GovernmentOpenStableClient(appEnv.client.government)
     }
 
+    @Bean
     fun worldHolidayClient(): WorldHolidayClient {
         return if (appEnv.client.abstract.useDummy)
             WorldHolidayDummyClient()

--- a/src/main/kotlin/io/mustelidae/riverotter/domain/calendar/holiday/HolidayCrawler.kt
+++ b/src/main/kotlin/io/mustelidae/riverotter/domain/calendar/holiday/HolidayCrawler.kt
@@ -5,20 +5,19 @@ import io.mustelidae.riverotter.config.NotSupportCountryException
 import io.mustelidae.riverotter.domain.calendar.holiday.country.KoreaHoliday
 import io.mustelidae.riverotter.domain.calendar.holiday.country.UnitedStateHoliday
 import io.mustelidae.riverotter.domain.calendar.holiday.repository.HolidayCalendarRepository
-import io.mustelidae.riverotter.domain.client.ClientHandler
+import io.mustelidae.riverotter.domain.client.abstractapi.WorldHolidayClient
+import io.mustelidae.riverotter.domain.client.korea.government.GovernmentOpenClient
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
 import java.util.Locale
 
 @Service
 class HolidayCrawler(
-    clientHandler: ClientHandler,
     private val env: AppEnvironment,
+    private val governmentOpenClient: GovernmentOpenClient,
+    private val worldHolidayClient: WorldHolidayClient,
     private val holidayCalendarRepository: HolidayCalendarRepository
 ) {
-    private val governmentOpenClient = clientHandler.governmentOpenClient()
-    private val worldHolidayClient = clientHandler.worldHolidayClient()
-
     fun crawling(year: Int, country: Locale): ObjectId {
         val countryHoliday = when (country) {
             Locale.KOREA -> KoreaHoliday(env.country.korea, governmentOpenClient, holidayCalendarRepository)

--- a/src/main/kotlin/io/mustelidae/riverotter/domain/client/abstractapi/WorldHolidayResources.kt
+++ b/src/main/kotlin/io/mustelidae/riverotter/domain/client/abstractapi/WorldHolidayResources.kt
@@ -16,7 +16,6 @@ class WorldHolidayResources {
                 val location: String,
                 val name: String,
                 val name_local: String,
-                val state: String,
                 val type: String,
                 val week_day: String
             )

--- a/src/test/kotlin/io/mustelidae/riverotter/domain/client/abstractapi/WorldHolidayStableClientTest.kt
+++ b/src/test/kotlin/io/mustelidae/riverotter/domain/client/abstractapi/WorldHolidayStableClientTest.kt
@@ -28,6 +28,6 @@ internal class WorldHolidayStableClientTest {
 
         // Then
         holidays.size shouldBe 1
-        holidays.first().type shouldBe "public_holiday"
+        holidays.first().type shouldBe "National"
     }
 }


### PR DESCRIPTION
클라이언트는 Handler를 이용하기 보단 Spring DI를 이용한다.
이 방법으로 바꾼 이유는 Test 코드 작성 시 mock을 하기 더 유용하기 때문이며 클라이언트가 N개로 확장 될 가능성이 적기 때문이다. 